### PR TITLE
Add security rel attribute to board member link

### DIFF
--- a/src/app/voting/page.js
+++ b/src/app/voting/page.js
@@ -31,7 +31,7 @@ export default function Voting() {
       <section>
         <h2 className="text-2xl font-bold mb-2">Role of a Board Member</h2>
         <p>Board members are stewards of our shared home. They oversee budgets and reserves, set policy, guide maintenance and vendor performance, communicate decisions, and listen—truly listen—to homeowners. It’s collaborative work that balances today’s needs with tomorrow’s plans. When board members do it well, homeowners feel informed, heard, and confident about where we’re headed. That’s the Windsong we all want to live in.</p>
-        <p className="mt-2"><Link href="/docs/board-member-101.pdf" target="_blank" className="text-lagoon underline">Download the official HOA Board Member overview (PDF)</Link></p>
+        <p className="mt-2"><Link href="/docs/board-member-101.pdf" target="_blank" rel="noopener noreferrer" className="text-lagoon underline">Download the official HOA Board Member overview (PDF)</Link></p>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- ensure Board Member PDF link uses `rel="noopener noreferrer"`

## Testing
- `npm test` *(fails: Missing script "test")*
- `SUPABASE_URL=http://localhost SUPABASE_ANON_KEY=test SUPABASE_SERVICE_ROLE=test npm run build`
- `npm audit`
- `npx -y lighthouse http://localhost:3000/voting --quiet --chrome-flags="--headless"` *(fails: Unable to connect to Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6898f69c220c8321b629e6f1891971d6