### PR TITLE
feat: improve admin session cookie

### DIFF
--- a/src/app/api/admin/endorsements/route.js
+++ b/src/app/api/admin/endorsements/route.js
@@ -1,12 +1,8 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { requireAdmin } from '../../../../lib/admin-session';
 
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE);
-
-function requireAdmin(req) {
-  const cookie = req.cookies.get('admin_session');
-  return cookie && cookie.value === '1';
-}
 
 export async function GET(req) {
   if (!requireAdmin(req)) {

--- a/src/app/api/admin/login/route.js
+++ b/src/app/api/admin/login/route.js
@@ -1,13 +1,22 @@
 import { NextResponse } from 'next/server';
+import { createSession } from '../../../../lib/admin-session';
 
 export async function POST(req) {
   const body = await req.json();
   const password = (body.password || '').toString();
   if (password === process.env.ADMIN_PASSWORD) {
+    const token = createSession();
     const res = NextResponse.json({ ok: true });
     // Set secure cookie. In production the secure flag ensures HTTPS only.
-    res.cookies.set('admin_session', '1', { path: '/', httpOnly: true, secure: true, maxAge: 60 * 60 * 8 });
+    res.cookies.set('admin_session', token, {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 60 * 60 * 8,
+    });
     return res;
   }
   return NextResponse.json({ ok: false }, { status: 401 });
 }
+

--- a/src/app/api/admin/qna/route.js
+++ b/src/app/api/admin/qna/route.js
@@ -1,12 +1,8 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { requireAdmin } from '../../../../lib/admin-session';
 
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE);
-
-function requireAdmin(req) {
-  const cookie = req.cookies.get('admin_session');
-  return cookie && cookie.value === '1';
-}
 
 export async function GET(req) {
   if (!requireAdmin(req)) {

--- a/src/lib/admin-session.js
+++ b/src/lib/admin-session.js
@@ -1,0 +1,14 @@
+import { randomUUID } from 'crypto';
+
+const sessions = new Set();
+
+export function createSession() {
+  const token = randomUUID();
+  sessions.add(token);
+  return token;
+}
+
+export function requireAdmin(req) {
+  const cookie = req.cookies.get('admin_session');
+  return cookie && sessions.has(cookie.value);
+}


### PR DESCRIPTION
## Summary
- set `sameSite: "lax"` and secure based on `NODE_ENV`
- replace constant admin session cookie with random UUID tokens
- centralize admin session verification across admin APIs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_6898f69a66408321b8a3d0c5467f74da