### PR TITLE
Organize Tailwind layers for global styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,28 +2,33 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Base styles */
-html, body {
-  height: 100%;
+@layer base {
+  /* Base styles */
+  html, body {
+    height: 100%;
+  }
+
+  body {
+    background-color: theme('colors.sand.DEFAULT');
+    color: theme('colors.charcoal.DEFAULT');
+    font-family: sans-serif;
+    overflow-x: hidden;
+  }
+
+  a {
+    @apply text-lagoon-light underline;
+  }
 }
 
-body {
-  background-color: theme('colors.sand.DEFAULT');
-  color: theme('colors.charcoal.DEFAULT');
-  font-family: sans-serif;
-  overflow-x: hidden;
+@layer components {
+  /* Quotes styling */
+  .quote {
+    @apply italic text-lg text-lagoon-light;
+  }
+
+  /* Utility for cards */
+  .card {
+    @apply bg-white rounded-xl shadow-md p-6;
+  }
 }
 
-a {
-  @apply text-lagoon-light underline;
-}
-
-/* Quotes styling */
-.quote {
-  @apply italic text-lg text-lagoon-light;
-}
-
-/* Utility for cards */
-.card {
-  @apply bg-white rounded-xl shadow-md p-6;
-}


### PR DESCRIPTION
## Summary
- group base HTML rules in a `@layer base` block
- move `.quote` and `.card` utilities into `@layer components`

## Testing
- `SUPABASE_URL=https://example.supabase.co SUPABASE_SERVICE_ROLE=service_role SUPABASE_ANON_KEY=anon_key npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898f69a194c832190a6e3c5683ae722