### PR TITLE
Use banner height for sticky nav

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,5 +1,5 @@
 import './globals.css';
-import Link from 'next/link';
+import StickyNav from '../components/StickyNav';
 
 export const metadata = {
   title: 'Doug Charles for Windsong Ranch HOA',
@@ -64,18 +64,7 @@ export default function RootLayout({ children }) {
           </div>
         </header>
         {/* Navigation */}
-        <nav className="bg-white shadow-sm py-3 px-4 sticky top-[4rem] sm:top-[3rem] z-40">
-          <div className="max-w-6xl mx-auto flex justify-between items-center">
-            <Link href="/" className="text-xl font-bold text-lagoon">Home</Link>
-            <div className="flex gap-4 text-sm sm:text-base">
-              <Link href="/voting" className="hover:underline">Voting Info</Link>
-              <Link href="/endorsements" className="hover:underline">Endorsements</Link>
-              <Link href="/qna" className="hover:underline">Q&A</Link>
-              {/* Use object with hash to ensure internal anchor works in Next.js */}
-              <Link href={{ pathname: '/', hash: 'get-involved' }} className="hover:underline">Get Involved</Link>
-            </div>
-          </div>
-        </nav>
+        <StickyNav />
         <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {children}
         </main>

--- a/src/components/StickyNav.jsx
+++ b/src/components/StickyNav.jsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRef, useEffect } from 'react';
+import Link from 'next/link';
+
+export default function StickyNav() {
+  const navRef = useRef(null);
+
+  useEffect(() => {
+    const navEl = navRef.current;
+    if (!navEl) return;
+    const banner = navEl.previousElementSibling;
+    if (!banner) return;
+
+    const updateOffset = () => {
+      navEl.style.setProperty('--banner-offset', `${banner.offsetHeight}px`);
+    };
+    updateOffset();
+    window.addEventListener('resize', updateOffset);
+    return () => window.removeEventListener('resize', updateOffset);
+  }, []);
+
+  return (
+    <nav
+      ref={navRef}
+      className="bg-white shadow-sm py-3 px-4 sticky [top:var(--banner-offset)] z-40"
+    >
+      <div className="max-w-6xl mx-auto flex justify-between items-center">
+        <Link href="/" className="text-xl font-bold text-lagoon">
+          Home
+        </Link>
+        <div className="flex gap-4 text-sm sm:text-base">
+          <Link href="/voting" className="hover:underline">
+            Voting Info
+          </Link>
+          <Link href="/endorsements" className="hover:underline">
+            Endorsements
+          </Link>
+          <Link href="/qna" className="hover:underline">
+            Q&A
+          </Link>
+          <Link
+            href={{ pathname: '/', hash: 'get-involved' }}
+            className="hover:underline"
+          >
+            Get Involved
+          </Link>
+        </div>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace fixed sticky nav offsets with a StickyNav component that derives its top position from the banner's height via a CSS variable
- Import the new component into the layout and remove hardcoded `top-[4rem] sm:top-[3rem]`

## Testing
- `npm test` *(fails: Missing script "test")*
- `SUPABASE_URL=https://example.com SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE=dummy npm run build`
- `node test_nav.js` (via puppeteer)

------
https://chatgpt.com/codex/tasks/task_e_6898f69557188321b1b71dc582b3ec2f