### PR TITLE
feat: set viewport metadata

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -4,6 +4,7 @@ import Link from 'next/link';
 export const metadata = {
   title: 'Doug Charles for Windsong Ranch HOA',
   description: 'Campaign site for Windsong Ranch HOA board election',
+  viewport: { width: 'device-width', initialScale: 1 },
 };
 
 const KEY_DATES = [


### PR DESCRIPTION
## Summary
- ensure viewport meta is set for device-width and initial scale

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: supabaseUrl is required)


------
https://chatgpt.com/codex/tasks/task_e_6898f69443588321974b5a52216a338d