### PR TITLE
feat: email notifications on form submissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/supabase-js": "^2.54.0",
         "autoprefixer": "10.4.13",
         "next": "^15.4.6",
+        "nodemailer": "^6.10.1",
         "postcss": "^8.5.6",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -1594,6 +1595,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@supabase/supabase-js": "^2.54.0",
     "autoprefixer": "10.4.13",
     "next": "^15.4.6",
+    "nodemailer": "^6.10.1",
     "postcss": "^8.5.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/app/api/endorsements/route.js
+++ b/src/app/api/endorsements/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { z } from 'zod';
 import { rateLimit } from '../../../lib/rateLimit';
+import { sendNotificationEmail } from '../../../lib/sendEmail';
 
 // Use anon key for public endpoints; this allows RLS to restrict selecting only approved
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_ANON_KEY);
@@ -41,6 +42,10 @@ export async function POST(req) {
     if (error) {
       return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
     }
+    sendNotificationEmail(
+      'New endorsement submitted',
+      `Name: ${name}\nMessage: ${message}`
+    ).catch((err) => console.error('Email failed', err));
     return NextResponse.json({ ok: true }, { status: 201 });
   } catch (err) {
     return NextResponse.json({ ok: false, error: err.message }, { status: 400 });

--- a/src/app/api/interest/route.js
+++ b/src/app/api/interest/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { z } from 'zod';
 import { rateLimit } from '../../../lib/rateLimit';
+import { sendNotificationEmail } from '../../../lib/sendEmail';
 
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_ANON_KEY);
 
@@ -31,6 +32,10 @@ export async function POST(req) {
     if (error) {
       return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
     }
+    sendNotificationEmail(
+      'New interest submission',
+      `Type: ${type}\nName: ${name}\nEmail: ${email}\nPhone: ${phone || ''}\nMessage: ${message || ''}`
+    ).catch((err) => console.error('Email failed', err));
     return NextResponse.json({ ok: true }, { status: 201 });
   } catch (err) {
     return NextResponse.json({ ok: false, error: err.message }, { status: 400 });

--- a/src/app/api/questions/route.js
+++ b/src/app/api/questions/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { z } from 'zod';
 import { rateLimit } from '../../../lib/rateLimit';
+import { sendNotificationEmail } from '../../../lib/sendEmail';
 
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_ANON_KEY);
 
@@ -43,6 +44,10 @@ export async function POST(req) {
     if (error) {
       return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
     }
+    sendNotificationEmail(
+      'New question submitted',
+      `Name: ${name}\nEmail: ${email}\nQuestion: ${question}`
+    ).catch((err) => console.error('Email failed', err));
     return NextResponse.json({ ok: true }, { status: 201 });
   } catch (err) {
     return NextResponse.json({ ok: false, error: err.message }, { status: 400 });

--- a/src/lib/sendEmail.js
+++ b/src/lib/sendEmail.js
@@ -1,0 +1,29 @@
+import nodemailer from 'nodemailer';
+
+export async function sendNotificationEmail(subject, text) {
+  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_SECURE, NOTIFY_EMAIL, SMTP_FROM } = process.env;
+  if (!SMTP_HOST || !SMTP_USER || !SMTP_PASS || !NOTIFY_EMAIL) {
+    console.error('Missing email environment variables.');
+    return;
+  }
+  try {
+    const transporter = nodemailer.createTransport({
+      host: SMTP_HOST,
+      port: SMTP_PORT ? parseInt(SMTP_PORT, 10) : 587,
+      secure: SMTP_SECURE === 'true',
+      auth: {
+        user: SMTP_USER,
+        pass: SMTP_PASS,
+      },
+    });
+
+    await transporter.sendMail({
+      from: SMTP_FROM || SMTP_USER,
+      to: NOTIFY_EMAIL,
+      subject,
+      text,
+    });
+  } catch (err) {
+    console.error('Failed to send email', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add nodemailer dependency and reusable sendNotificationEmail helper
- notify admin by email when questions, endorsements, or interest forms are submitted

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*


------
https://chatgpt.com/codex/tasks/task_e_6898ff6f7ccc832197cbdcb95e035c22