### PR TITLE
Reorder endorsements and community sections on homepage

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -156,6 +156,23 @@ export default function Home() {
         <div className="quote">“Leadership isn’t about titles—it’s about service, stewardship, and listening to every voice.”</div>
       </section>
 
+      {/* Endorsements display */}
+      {endorsements.length > 0 && (
+        <section>
+          <h2 className="text-2xl sm:text-3xl font-bold mb-4">Endorsements</h2>
+          {/* Use auto-rotating carousel */}
+          <EndorsementsCarousel endorsements={endorsements} />
+        </section>
+      )}
+
+      {/* Lifestyle section */}
+      <section>
+        <h2 className="text-2xl sm:text-3xl font-bold mb-4">We Live in a Community Worth Protecting</h2>
+        <p>
+          From <strong>The Lagoon</strong> and miles of trails to parks, amphitheater events, and shared green spaces—Windsong is built for connection. Good governance keeps it thriving today and strong for tomorrow.
+        </p>
+      </section>
+
       {/* Neighborhood unity */}
       <section>
         <h2 className="text-2xl sm:text-3xl font-bold mb-4">One Windsong, Every Voice</h2>
@@ -173,14 +190,6 @@ export default function Home() {
             );
           })}
         </div>
-      </section>
-
-      {/* Lifestyle section */}
-      <section>
-        <h2 className="text-2xl sm:text-3xl font-bold mb-4">We Live in a Community Worth Protecting</h2>
-        <p>
-          From <strong>The Lagoon</strong> and miles of trails to parks, amphitheater events, and shared green spaces—Windsong is built for connection. Good governance keeps it thriving today and strong for tomorrow.
-        </p>
       </section>
 
       {/* Submit a question */}
@@ -220,15 +229,6 @@ export default function Home() {
               </div>
             ))}
           </div>
-        </section>
-      )}
-
-      {/* Endorsements display */}
-      {endorsements.length > 0 && (
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-bold mb-4">What Your Neighbors Are Saying</h2>
-          {/* Use auto‑rotating carousel */}
-          <EndorsementsCarousel endorsements={endorsements} />
         </section>
       )}
 


### PR DESCRIPTION
## Summary
- Rename "What Your Neighbors Are Saying" to "Endorsements" and show it directly below the Meet Doug section
- Place "We Live in a Community Worth Protecting" ahead of "One Windsong, Every Voice" for updated flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_689902abb57483218944f5673deb54e3