### PR TITLE
feat: switch to Resend API for email notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# WSR Board Election site
+
+## Custom domain
+
+1. In the Vercel dashboard open **Project → Settings → Domains** and add `dougcharles.com`.
+2. Update DNS:
+   - **Vercel nameservers (recommended):** set your registrar to use the nameservers shown by Vercel.
+   - **Keep existing DNS:** create records
+        - `A` for `@` → `76.76.21.21`
+        - `CNAME` for `www` → `cname.vercel-dns.com`
+3. Wait for propagation and visit `https://www.dougcharles.com` to verify.
+
+## Resend email
+
+1. In the [Resend dashboard](https://resend.com) add the domain `dougcharles.com`.
+2. Add the DKIM and SPF TXT records provided by Resend to your DNS host and wait for verification. For `dougcharles.com`, Resend supplied these records:
+
+   | Type | Name | Value | TTL | Notes |
+   | ---- | ---- | ----- | --- | ----- |
+   | MX   | send | feedback-smtp.us-east-1.amazonses.com | 60 | priority 10 |
+   | TXT  | send | v=spf1 include:amazonses.com ~all | 60 | SPF |
+   | TXT  | resend._domainkey | p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDTMgfUzxqEMhniJ3X2ot0uvaM3UdO2/y9wbm+4yu4W+51UO5f1j3lsqHSEgcAlY4HkbFuYHVctySNrsPytBv+vpJyr0hM88Ifnvffw8se/L0+G5JfdST6BLfCoS2GTlThna4BlRTb4lvzLNsm6uMNeZuF8ZS+urE/P6IhFuZGPCQIDAQAB | Auto | DKIM |
+   | TXT  | _dmarc | v=DMARC1; p=none; | Auto | DMARC |
+
+3. Set the following environment variables in Vercel (or a local `.env` file) before deploying:
+
+```
+RESEND_API_KEY=<your Resend API key>
+NOTIFY_EMAIL=dbcharles@me.com
+SMTP_FROM=no-reply@dougcharles.com
+```
+
+   The Vercel Resend integration automatically populates `RESEND_API_KEY`.
+
+4. Redeploy and test any feature that calls `sendNotificationEmail`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
         "@supabase/supabase-js": "^2.54.0",
         "autoprefixer": "10.4.13",
         "next": "^15.4.6",
-        "nodemailer": "^6.10.1",
         "postcss": "^8.5.6",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "resend": "^6.0.1",
         "tailwindcss": "3.3.3",
         "zod": "^3.25.76"
       }
@@ -1596,15 +1596,6 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
     },
-    "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1886,6 +1877,23 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.0.1.tgz",
+      "integrity": "sha512-xNZ0gKAOqQcH83lXsqNOwBbpKROnsZpQr9mXRdG6hrHTF9G9Il2pkoTRtq7rJzXMvCZX+I79oahsbSeaYOWRFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-email/render": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@supabase/supabase-js": "^2.54.0",
     "autoprefixer": "10.4.13",
     "next": "^15.4.6",
-    "nodemailer": "^6.10.1",
+    "resend": "^6.0.1",
     "postcss": "^8.5.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/lib/sendEmail.js
+++ b/src/lib/sendEmail.js
@@ -1,24 +1,16 @@
-import nodemailer from 'nodemailer';
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
 
 export async function sendNotificationEmail(subject, text) {
-  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_SECURE, NOTIFY_EMAIL, SMTP_FROM } = process.env;
-  if (!SMTP_HOST || !SMTP_USER || !SMTP_PASS || !NOTIFY_EMAIL) {
+  const { RESEND_API_KEY, NOTIFY_EMAIL, SMTP_FROM } = process.env;
+  if (!RESEND_API_KEY || !NOTIFY_EMAIL || !SMTP_FROM) {
     console.error('Missing email environment variables.');
     return;
   }
   try {
-    const transporter = nodemailer.createTransport({
-      host: SMTP_HOST,
-      port: SMTP_PORT ? parseInt(SMTP_PORT, 10) : 587,
-      secure: SMTP_SECURE === 'true',
-      auth: {
-        user: SMTP_USER,
-        pass: SMTP_PASS,
-      },
-    });
-
-    await transporter.sendMail({
-      from: SMTP_FROM || SMTP_USER,
+    await resend.emails.send({
+      from: SMTP_FROM,
       to: NOTIFY_EMAIL,
       subject,
       text,
@@ -27,3 +19,4 @@ export async function sendNotificationEmail(subject, text) {
     console.error('Failed to send email', err);
   }
 }
+


### PR DESCRIPTION
## Summary
- replace Nodemailer helper with Resend SDK so Vercel Resend integration works out of the box
- document new `RESEND_API_KEY`, `SMTP_FROM`, and `NOTIFY_EMAIL` env vars
- add `resend` dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_689910fc2d2c832189dc3dcf12405bbd