### PR TITLE
Reorder endorsements, streamline form access, and ensure email notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "postcss": "^8.5.6",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "resend": "^6.0.1",
         "tailwindcss": "3.3.3",
         "zod": "^3.25.76"
       }
@@ -1886,6 +1887,23 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.0.1.tgz",
+      "integrity": "sha512-xNZ0gKAOqQcH83lXsqNOwBbpKROnsZpQr9mXRdG6hrHTF9G9Il2pkoTRtq7rJzXMvCZX+I79oahsbSeaYOWRFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-email/render": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "postcss": "^8.5.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "resend": "^6.0.1",
     "tailwindcss": "3.3.3",
     "zod": "^3.25.76"
   }

--- a/src/app/endorsements/page.js
+++ b/src/app/endorsements/page.js
@@ -35,7 +35,7 @@ export default function EndorsementsPage() {
       <div className="mt-6">
         {/* Use Next.js Link with hash to ensure smooth internal navigation */}
         <Link
-          href={{ pathname: '/', hash: 'get-involved' }}
+          href={{ pathname: '/', query: { form: 'endorsement' }, hash: 'get-involved' }}
           className="text-coral hover:underline font-medium"
         >
           Endorse Doug

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import EndorsementsCarousel from '../components/EndorsementsCarousel';
 
 export default function Home() {
@@ -35,6 +36,12 @@ export default function Home() {
       }
     }
     loadData();
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const ft = params.get('form');
+    if (ft) setFormType(ft);
   }, []);
 
   async function submitQuestion(e) {
@@ -97,6 +104,14 @@ export default function Home() {
     'bg-lagoon-light'
   ];
 
+  const formOptions = [
+    { value: 'updates', label: 'Get Updates' },
+    { value: 'volunteer', label: 'Volunteer' },
+    { value: 'host', label: 'Host a Home Meeting' },
+    { value: 'meeting', label: 'Request a Meeting' },
+    { value: 'endorsement', label: 'Endorse Doug' },
+  ];
+
   return (
     <div className="space-y-16">
       {/* Hero Section */}
@@ -118,7 +133,12 @@ export default function Home() {
           I’m <strong>Doug Charles</strong>, and I’m running for <strong>purpose</strong>—to listen, advocate, and represent every neighborhood in Windsong Ranch with transparency, fiscal responsibility, and an open door for every neighbor.
         </p>
         <div className="flex flex-wrap justify-center gap-4 mt-4">
-          <a href="#get-involved" className="px-6 py-3 bg-coral text-white rounded-full hover:bg-coral/90">Endorse Doug</a>
+          <Link
+            href={{ pathname: '/', query: { form: 'endorsement' }, hash: 'get-involved' }}
+            className="px-6 py-3 bg-coral text-white rounded-full hover:bg-coral/90"
+          >
+            Endorse Doug
+          </Link>
           <a href="#get-involved" className="px-6 py-3 bg-lagoon-light text-lagoon rounded-full hover:bg-lagoon-light/90">Get Involved</a>
         </div>
       </section>
@@ -156,6 +176,23 @@ export default function Home() {
         <div className="quote">“Leadership isn’t about titles—it’s about service, stewardship, and listening to every voice.”</div>
       </section>
 
+      {/* Endorsements display */}
+      {endorsements.length > 0 && (
+        <section>
+          <h2 className="text-2xl sm:text-3xl font-bold mb-4">Endorsements</h2>
+          {/* Use auto-rotating carousel */}
+          <EndorsementsCarousel endorsements={endorsements} />
+        </section>
+      )}
+
+      {/* Lifestyle section */}
+      <section>
+        <h2 className="text-2xl sm:text-3xl font-bold mb-4">We Live in a Community Worth Protecting</h2>
+        <p>
+          From <strong>The Lagoon</strong> and miles of trails to parks, amphitheater events, and shared green spaces—Windsong is built for connection. Good governance keeps it thriving today and strong for tomorrow.
+        </p>
+      </section>
+
       {/* Neighborhood unity */}
       <section>
         <h2 className="text-2xl sm:text-3xl font-bold mb-4">One Windsong, Every Voice</h2>
@@ -173,14 +210,6 @@ export default function Home() {
             );
           })}
         </div>
-      </section>
-
-      {/* Lifestyle section */}
-      <section>
-        <h2 className="text-2xl sm:text-3xl font-bold mb-4">We Live in a Community Worth Protecting</h2>
-        <p>
-          From <strong>The Lagoon</strong> and miles of trails to parks, amphitheater events, and shared green spaces—Windsong is built for connection. Good governance keeps it thriving today and strong for tomorrow.
-        </p>
       </section>
 
       {/* Submit a question */}
@@ -223,29 +252,30 @@ export default function Home() {
         </section>
       )}
 
-      {/* Endorsements display */}
-      {endorsements.length > 0 && (
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-bold mb-4">What Your Neighbors Are Saying</h2>
-          {/* Use auto‑rotating carousel */}
-          <EndorsementsCarousel endorsements={endorsements} />
-        </section>
-      )}
-
       {/* Get involved section */}
       <section id="get-involved">
         <h2 className="text-2xl sm:text-3xl font-bold mb-4">Join the Effort</h2>
         <p className="mb-4">Select how you'd like to participate—Get Updates, Volunteer, Host a Home Meeting, Request a Meeting, or Endorse Doug.</p>
         <form onSubmit={submitGetInvolved} className="space-y-3 max-w-xl">
           <div className="flex flex-col">
-            <label htmlFor="ftype" className="font-medium mb-1">I'm interested in*</label>
-            <select id="ftype" value={formType} onChange={(e) => setFormType(e.target.value)} className="border p-2 rounded">
-              <option value="updates">Get Updates</option>
-              <option value="volunteer">Volunteer</option>
-              <option value="host">Host a Home Meeting</option>
-              <option value="meeting">Request a Meeting</option>
-              <option value="endorsement">Endorse Doug</option>
-            </select>
+            <span className="font-medium mb-1">I'm interested in*</span>
+            <div className="flex flex-wrap gap-2">
+              {formOptions.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => setFormType(opt.value)}
+                  className={`px-4 py-2 rounded-full border ${
+                    formType === opt.value
+                      ? 'bg-lagoon text-white border-lagoon'
+                      : 'bg-white text-lagoon border-lagoon hover:bg-lagoon/10'
+                  }`}
+                  aria-pressed={formType === opt.value}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
           </div>
           <div className="flex flex-col">
             <label htmlFor="fname" className="font-medium mb-1">Name*</label>


### PR DESCRIPTION
## Summary
- Rename "What Your Neighbors Are Saying" to "Endorsements" and show it directly below the Meet Doug section
- Place "We Live in a Community Worth Protecting" ahead of "One Windsong, Every Voice" for updated flow
- Replace the Join the Effort dropdown with buttons and allow direct linking to pre-selected endorsement form
- Parse the `form` query parameter from `window.location` instead of `useSearchParams` so the page builds without a suspense boundary
- Send notification emails via Resend with an SMTP fallback so interest, question, and endorsement submissions trigger alerts

## Testing
- `npm test` *(fails: Missing script "test")*
- `SUPABASE_URL=http://localhost SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE=service RESEND_API_KEY=key NOTIFY_EMAIL=test@example.com SMTP_FROM=test@example.com npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689902abb57483218944f5673deb54e3