### PR TITLE
feat: use Resend for notification emails

### DIFF
--- a/src/lib/sendEmail.js
+++ b/src/lib/sendEmail.js
@@ -1,0 +1,24 @@
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+/**
+ * Send a notification email using the Resend API.
+ *
+ * @param {string} subject - The email subject line.
+ * @param {string} text - Plain text body of the message.
+ * @returns {Promise<void>} Resolves when the email request has been sent.
+ */
+export async function sendNotificationEmail(subject, text) {
+  const from = process.env.SMTP_FROM;
+  const to = process.env.NOTIFY_EMAIL;
+  if (!from || !to) {
+    throw new Error('SMTP_FROM and NOTIFY_EMAIL must be configured');
+  }
+  await resend.emails.send({
+    from,
+    to,
+    subject,
+    text,
+  });
+}


### PR DESCRIPTION
## Summary
- add missing sendEmail helper that sends notifications via Resend API

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899392c31948321bae372db25907dbb