### PR TITLE
Fix countdown banner spacing and nav link

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -34,6 +34,7 @@ export default function RootLayout({ children }) {
   const now = new Date().toISOString();
   const { phase, days } = getCountdown(now);
   const countdownLabel = phase === 'pre' ? 'Voting opens in' : phase === 'open' ? 'Voting closes in' : '';
+  const countdownText = `${countdownLabel} ${days} day${days === 1 ? '' : 's'}`;
 
   return (
     <html lang="en">
@@ -52,13 +53,13 @@ export default function RootLayout({ children }) {
               </div>
             </div>
             {phase !== 'post' && (
-                <div className="ml-auto text-right">
-                  {/* Highlight the countdown label and number so it stands out */}
-                  <span className="font-semibold text-coral whitespace-nowrap">
-                    <span className="uppercase">{countdownLabel}</span> {days} day{days === 1 ? '' : 's'}
-                  </span>
-                </div>
-              )}
+              <div className="ml-auto text-right">
+                {/* Highlight the countdown label and number so it stands out */}
+                <span className="font-semibold text-coral whitespace-nowrap uppercase">
+                  {countdownText}
+                </span>
+              </div>
+            )}
             </div>
           </header>
         {/* Navigation */}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -202,7 +202,7 @@ export default function Home() {
       </section>
 
       {/* Meet Doug */}
-      <section>
+      <section id="about">
         <h2 className="text-2xl sm:text-3xl font-bold mb-4">Meet Doug</h2>
         <p className="mb-4">
           <strong>Doug Charles</strong> has proudly called Windsong Ranch home since 2015, living in both Crosswater and the Peninsula. As a long‑time resident, husband, and father, he believes leadership is an act of service—not a pursuit of status. With more than 25&nbsp;years of executive leadership in financial services, Doug currently serves as a Senior Vice President overseeing multi‑million‑dollar budgets, complex vendor contracts, and national compliance operations. Doug’s civic service runs deep: two terms on Prosper’s Planning &amp; Zoning Commission, membership on the Town Bond Committee, and previous roles on HOA boards. In every position, he has championed fair representation, strategic growth, and fiscal stewardship. Doug listens first, leads collaboratively, and believes every assessment, contract, and resource should reflect homeowners’ interests—not just a select few. As Windsong Ranch transitions toward full homeowner governance, he is committed to guiding the community with transparency, integrity, and a deep love for his neighbors.

--- a/src/components/StickyNav.jsx
+++ b/src/components/StickyNav.jsx
@@ -40,10 +40,10 @@ export default function StickyNav() {
             Q&A
           </Link>
           <Link
-            href={{ pathname: '/', hash: 'get-involved' }}
+            href={{ pathname: '/', hash: 'about' }}
             className="hover:underline"
           >
-            Get Involved
+            About Doug
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Prevent stray space in countdown and render full uppercase message.
- Rename nav item to “About Doug” and link to new anchor section.

## Testing
- `npm test` *(fails: Missing script "test")*
- `NEXT_TELEMETRY_DISABLED=1 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689947bbc22c8321b68ed76d4f6f8201