### PR TITLE
Revise content and mobile experience

### DIFF
--- a/src/app/api/interest/route.js
+++ b/src/app/api/interest/route.js
@@ -13,7 +13,7 @@ export async function POST(req) {
   }
   try {
     const schema = z.object({
-      type: z.string().max(200).optional().default('updates'),
+      types: z.array(z.string()).min(1, 'Select at least one option'),
       name: z.string().min(1, 'Name is required').max(200),
       email: z.string().email('Invalid email').max(200),
       phone: z.string().max(200).optional().nullable(),
@@ -25,7 +25,8 @@ export async function POST(req) {
       const errorMessage = parsed.error.errors.map(e => e.message).join(', ');
       return NextResponse.json({ ok: false, error: errorMessage }, { status: 400 });
     }
-    const { type, name, email, phone, message } = parsed.data;
+    const { types, name, email, phone, message } = parsed.data;
+    const type = types.join(', ');
     const { error } = await supabase
       .from('interest')
       .insert({ type, name, email, phone: phone ?? null, message: message ?? null });
@@ -34,7 +35,7 @@ export async function POST(req) {
     }
     sendNotificationEmail(
       'New interest submission',
-      `Type: ${type}\nName: ${name}\nEmail: ${email}\nPhone: ${phone || ''}\nMessage: ${message || ''}`
+      `Types: ${type}\nName: ${name}\nEmail: ${email}\nPhone: ${phone || ''}\nMessage: ${message || ''}`
     ).catch((err) => console.error('Email failed', err));
     return NextResponse.json({ ok: true }, { status: 201 });
   } catch (err) {

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,5 +1,6 @@
 import './globals.css';
 import StickyNav from '../components/StickyNav';
+import MobileCTA from '../components/MobileCTA';
 
 export const metadata = {
   title: 'Doug Charles for Windsong Ranch HOA',
@@ -34,38 +35,40 @@ export default function RootLayout({ children }) {
   const now = new Date().toISOString();
   const { phase, days } = getCountdown(now);
   const countdownLabel = phase === 'pre' ? 'Voting opens in' : phase === 'open' ? 'Voting closes in' : '';
+  const countdownText = `${countdownLabel} ${days} day${days === 1 ? '' : 's'}`;
 
   return (
     <html lang="en">
       <body>
         {/* Sticky key dates banner */}
-        <header className="bg-lagoon text-white text-sm sm:text-base py-2 px-4 sticky top-0 z-50 shadow-md">
-          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-y-1">
-            <div className="flex flex-col sm:flex-row flex-wrap gap-x-4 gap-y-1">
-              {KEY_DATES.map((item, idx) => (
-                <div key={idx} className="whitespace-nowrap">
-                  <strong>{item.label}</strong> – {item.date}
-                </div>
-              ))}
-              <div className="whitespace-nowrap">
-                <strong>One vote per home address by a Title Owner</strong>
+        <header className="bg-lagoon text-white text-xs sm:text-sm py-2 px-4 sticky top-0 z-50 shadow-md space-y-2">
+          <div className="flex flex-wrap justify-center gap-2">
+            {KEY_DATES.map((item, idx) => (
+              <div
+                key={idx}
+                className="bg-lagoon-light text-lagoon px-3 py-1 rounded-full font-semibold uppercase"
+              >
+                {item.date} – {item.label}
               </div>
+            ))}
+            <div className="bg-lagoon-light text-lagoon px-3 py-1 rounded-full font-semibold uppercase">
+              1 VOTE PER ADDRESS (TITLE OWNER)
             </div>
-            {phase !== 'post' && (
-                <div className="ml-auto text-right">
-                  {/* Highlight the countdown label and number so it stands out */}
-                  <span className="font-semibold text-coral whitespace-nowrap">
-                    <span className="uppercase">{countdownLabel}</span> {days} day{days === 1 ? '' : 's'}
-                  </span>
-                </div>
-              )}
+          </div>
+          {phase !== 'post' && (
+            <div className="text-center">
+              <span className="font-semibold text-coral uppercase whitespace-nowrap">
+                {countdownText}
+              </span>
             </div>
-          </header>
+          )}
+        </header>
         {/* Navigation */}
         <StickyNav />
-        <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 pb-24">
           {children}
         </main>
+        <MobileCTA />
         <footer className="bg-white py-6 mt-16 border-t">
           <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-sm text-center">
             Self‑funded by Doug Charles. | © {new Date().getFullYear()} Windsong Ranch HOA Election

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -20,6 +20,9 @@ import {
   Home as HomeIcon,
   Compass,
   Link as LinkIcon,
+  Megaphone,
+  Users,
+  ClipboardList,
 } from 'lucide-react';
 
 export default function Home() {
@@ -31,7 +34,7 @@ export default function Home() {
   const [qThanks, setQThanks] = useState(false);
   // Form state for get involved / endorsement
   const [mode, setMode] = useState('involved');
-  const [formType, setFormType] = useState('updates');
+  const [selected, setSelected] = useState([]);
   const [form, setForm] = useState({ name: '', email: '', phone: '', message: '' });
   const [submitMsg, setSubmitMsg] = useState('');
 
@@ -61,8 +64,6 @@ export default function Home() {
     const ft = params.get('form');
     if (ft === 'endorsement') {
       setMode('endorsement');
-    } else if (ft) {
-      setFormType(ft);
     }
   }, []);
 
@@ -101,16 +102,23 @@ export default function Home() {
         const res = await fetch('/api/interest', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ type: formType, name: form.name, email: form.email, phone: form.phone, message: form.message }),
+          body: JSON.stringify({ types: selected, name: form.name, email: form.email, phone: form.phone, message: form.message }),
         });
         if (res.ok) {
           setSubmitMsg('Thank you! We will be in touch.');
           setForm({ name: '', email: '', phone: '', message: '' });
+          setSelected([]);
         }
       }
     } catch (err) {
       console.error(err);
     }
+  }
+
+  function toggleSelection(value) {
+    setSelected((prev) =>
+      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]
+    );
   }
 
   // Neighborhood list to display as cards
@@ -119,9 +127,11 @@ export default function Home() {
     { name: 'Cadence', icon: AudioWaveform },
     { name: 'Creekside', icon: Waves },
     { name: 'Crosswater', icon: Cross },
+    { name: 'The Crossing', icon: LinkIcon },
     { name: 'The Enclave', icon: Shield },
     { name: 'Lakeside', icon: Waves },
     { name: 'The Landing', icon: PlaneLanding },
+    { name: 'Northview', icon: Compass },
     { name: 'The Overlook', icon: Eye },
     { name: 'The Peninsula', icon: MapPinned },
     { name: 'The Pinnacle', icon: Mountain },
@@ -129,8 +139,6 @@ export default function Home() {
     { name: 'The Summit', icon: MountainSnow },
     { name: 'The Townhomes', icon: Building2 },
     { name: 'The Villas', icon: HomeIcon },
-    { name: 'Northview', icon: Compass },
-    { name: 'The Crossing', icon: LinkIcon },
   ];
   // Colour palette for bespoke neighbourhood icons; cycles through these values
   const neighbourhoodColours = [
@@ -140,10 +148,10 @@ export default function Home() {
   ];
 
   const formOptions = [
-    { value: 'updates', label: 'Get Updates' },
-    { value: 'volunteer', label: 'Volunteer' },
-    { value: 'host', label: 'Host a Home Meeting' },
-    { value: 'meeting', label: 'Request a Meeting' },
+    { value: 'updates', label: 'Get Updates', desc: 'Receive campaign news and reminders' },
+    { value: 'volunteer', label: 'Volunteer', desc: 'Help distribute materials' },
+    { value: 'host', label: 'Host a Home Meeting', desc: 'Invite neighbours for a discussion' },
+    { value: 'meeting', label: 'Request a Meeting', desc: 'Chat with Doug one-on-one' },
   ];
 
   return (
@@ -160,11 +168,12 @@ export default function Home() {
           priority
         />
         <h1 className="text-4xl sm:text-5xl font-extrabold text-lagoon">Your Voice. Your Vote. Our Windsong.</h1>
+        <h2 className="text-xl sm:text-2xl font-semibold text-lagoon">For the first time, our voices can shape Windsong’s future.</h2>
         <p className="max-w-3xl mx-auto text-lg sm:text-xl leading-relaxed">
-          For the first time, homeowners will elect two representatives to our HOA Board—joining three developer-appointed members. These seats will set the tone for the transition to a fully homeowner-led board in the near future.
+          Homeowners will elect two representatives to our HOA Board—joining three developer-appointed members. These seats will set the tone for the transition to a fully homeowner-led board in the near future.
         </p>
         <p className="max-w-3xl mx-auto text-lg sm:text-xl">
-          I’m <strong>Doug Charles</strong>—and I’m running to listen, advocate, and represent every neighborhood in Windsong Ranch with transparency, fiscal responsibility, and an open door for every neighbor.
+          I’m <strong>Doug Charles.</strong> I’m running to <strong>listen</strong>, <strong>advocate</strong> and <strong>represent</strong> every neighbourhood in Windsong Ranch – with transparency, fiscal responsibility and an open door for every neighbour.
         </p>
         <div className="flex flex-wrap justify-center gap-4 mt-4">
           <Link
@@ -179,33 +188,37 @@ export default function Home() {
 
       {/* Promises */}
       <section className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        <div className="card">
-          <h3 className="text-xl font-semibold mb-2">Ensure Transparency & Accountability</h3>
-          <p>I will ensure every assessment, contract, and decision is clear and accessible to you. I’ll fight for open budgets, public explanations, and genuine two‑way dialogue.</p>
+        <div className="card text-center">
+          <Shield className="w-8 h-8 text-lagoon mb-3 mx-auto" aria-hidden="true" />
+          <h3 className="text-xl font-semibold mb-2">Deliver Transparency &amp; Accountability</h3>
+          <p>Every assessment, contract and decision will be clear and accessible. I’ll publish plain-language budget summaries and post-meeting Q&amp;As.</p>
           <p className="quote mt-2">“Transparent governance isn’t optional—it’s a promise I make to you.”</p>
         </div>
-        <div className="card">
-          <h3 className="text-xl font-semibold mb-2">Empower Homeowners & Amplify Your Voice</h3>
-          <p>Homeowners—not developers—should drive our policies. We’ll staff committees with Windsong’s talented, passionate, and expert residents—and I’ll always be available to listen and advocate for your concerns.</p>
+        <div className="card text-center">
+          <Megaphone className="w-8 h-8 text-lagoon mb-3 mx-auto" aria-hidden="true" />
+          <h3 className="text-xl font-semibold mb-2">Amplify Your Voice with Homeowner‑Led Committees</h3>
+          <p>Stand up homeowner-led committees – Finance, Landscape, Amenities – and publish applications quarterly. I’ll listen and advocate for your concerns.</p>
           <p className="quote mt-2">“Boards don’t own communities—homeowners do. Together we will build a board that serves you, not itself.”</p>
         </div>
-        <div className="card">
-          <h3 className="text-xl font-semibold mb-2">Unite Windsong</h3>
-          <p>Townhomes, Villas, Peninsula, Crosswater, and every street—no neighborhood left behind. Our diversity is our strength, and we are stronger together.</p>
+        <div className="card text-center">
+          <Users className="w-8 h-8 text-lagoon mb-3 mx-auto" aria-hidden="true" />
+          <h3 className="text-xl font-semibold mb-2">Unite as One Windsong</h3>
+          <p>No neighbourhood left behind – Townhomes, Villas, Peninsula, Crosswater and every street.</p>
           <p className="quote mt-2">“Diverse in character, united in purpose—one Windsong, one voice.”</p>
         </div>
-        <div className="card">
-          <h3 className="text-xl font-semibold mb-2">Protect Our Lifestyle & Practice Fiscal Stewardship</h3>
-          <p>I’ll safeguard our reserve fund, minimize unnecessary assessment increases, and ensure our contracts deliver real value. We’ll protect and enhance our amenities—The Lagoon, trails, parks, and green spaces—so Windsong stays vibrant and thriving.</p>
+        <div className="card text-center">
+          <ClipboardList className="w-8 h-8 text-lagoon mb-3 mx-auto" aria-hidden="true" />
+          <h3 className="text-xl font-semibold mb-2">Protect Our Lifestyle with Fiscal Stewardship</h3>
+          <p>Safeguard reserves, pressure‑test vendor contracts and minimise fee increases. Publish an annual value‑for‑dues report so homeowners see where every dollar goes.</p>
           <p className="quote mt-2">“Our lifestyle is our legacy. I’ll ensure it’s preserved for all of us, today and tomorrow.”</p>
         </div>
       </section>
 
       {/* Meet Doug */}
-      <section>
+      <section id="about">
         <h2 className="text-2xl sm:text-3xl font-bold mb-4">Meet Doug</h2>
         <p className="mb-4">
-          <strong>Doug Charles</strong> has proudly called Windsong Ranch home since 2015, living in both Crosswater and the Peninsula. As a long‑time resident, husband, and father, he believes leadership is an act of service—not a pursuit of status. With more than 25&nbsp;years of executive leadership in financial services, Doug currently serves as a Senior Vice President overseeing multi‑million‑dollar budgets, complex vendor contracts, and national compliance operations. Doug’s civic service runs deep: two terms on Prosper’s Planning &amp; Zoning Commission, membership on the Town Bond Committee, and previous roles on HOA boards. In every position, he has championed fair representation, strategic growth, and fiscal stewardship. Doug listens first, leads collaboratively, and believes every assessment, contract, and resource should reflect homeowners’ interests—not just a select few. As Windsong Ranch transitions toward full homeowner governance, he is committed to guiding the community with transparency, integrity, and a deep love for his neighbors.
+          <strong>Doug Charles</strong> has proudly called Windsong Ranch home since 2015, living in both Crosswater and the Peninsula. As a long‑time resident, husband, and father, he believes leadership is an act of service—not a pursuit of status. With more than 25&nbsp;years of executive leadership in financial services, Doug currently serves as a Senior Vice President overseeing multi‑million‑dollar budgets, complex vendor contracts, and national compliance operations. He’s managed those budgets to reduce risks, improve services and prevent surprise fee increases. Doug’s civic service runs deep: two terms on Prosper’s Planning &amp; Zoning Commission, membership on the Town Bond Committee, and previous roles on HOA boards. In every position, he has championed fair representation, strategic growth, and fiscal stewardship. When he isn’t working, you’ll find him with his family at the Lagoon—one of many reasons he loves Windsong. Doug listens first, leads collaboratively, and believes every assessment, contract, and resource should reflect homeowners’ interests—not just a select few. As Windsong Ranch transitions toward full homeowner governance, he is committed to guiding the community with transparency, integrity, and a deep love for his neighbors.
         </p>
         <div className="quote">“Leadership isn’t about titles—it’s about service, stewardship, and listening to every voice.”</div>
       </section>
@@ -222,9 +235,7 @@ export default function Home() {
       {/* Lifestyle section */}
       <section>
         <h2 className="text-2xl sm:text-3xl font-bold mb-4">Protect Our Community</h2>
-        <p>
-          From <strong>The Lagoon</strong> and miles of trails to parks, amphitheater events, and shared green spaces—Windsong is built for connection. Good governance keeps it thriving today and strong for tomorrow.
-        </p>
+        <p>Protect and enhance our amenities – <strong>The Lagoon</strong>, trails, parks and amphitheatre – through transparent budgeting and effective vendor management.</p>
       </section>
 
       {/* Neighborhood unity */}
@@ -250,22 +261,22 @@ export default function Home() {
       {/* Submit a question */}
       <section id="qna">
         <h2 className="text-2xl sm:text-3xl font-bold mb-4">Ask Doug a Question</h2>
-        <p className="mb-4">Have a question for the Candidate Forum—or anytime? Send it here. I’ll answer and post them on this page, so check back soon.</p>
+        <p className="mb-4">Submit your question for the Candidate Forum; answered questions will be posted here within 48 hours.</p>
         {qThanks ? (
           <p className="text-lagoon font-semibold">Thank you for your question! I’ll post an answer here soon.</p>
         ) : (
           <form onSubmit={submitQuestion} className="space-y-3 max-w-xl">
             <div className="flex flex-col">
               <label htmlFor="qname" className="font-medium mb-1">Name*</label>
-              <input id="qname" required type="text" value={qForm.name} onChange={(e) => setQForm({ ...qForm, name: e.target.value })} className="border p-2 rounded" />
+              <input id="qname" name="name" autoComplete="name" required type="text" value={qForm.name} onChange={(e) => setQForm({ ...qForm, name: e.target.value })} className="border p-2 rounded" />
             </div>
             <div className="flex flex-col">
               <label htmlFor="qemail" className="font-medium mb-1">Email*</label>
-              <input id="qemail" required type="email" value={qForm.email} onChange={(e) => setQForm({ ...qForm, email: e.target.value })} className="border p-2 rounded" />
+              <input id="qemail" name="email" autoComplete="email" required type="email" value={qForm.email} onChange={(e) => setQForm({ ...qForm, email: e.target.value })} className="border p-2 rounded" />
             </div>
             <div className="flex flex-col">
               <label htmlFor="question" className="font-medium mb-1">Your Question*</label>
-              <textarea id="question" required rows={4} value={qForm.question} onChange={(e) => setQForm({ ...qForm, question: e.target.value })} className="border p-2 rounded"></textarea>
+              <textarea id="question" name="question" required rows={5} value={qForm.question} onChange={(e) => setQForm({ ...qForm, question: e.target.value })} className="border p-2 rounded"></textarea>
             </div>
             <button type="submit" className="bg-coral text-white px-5 py-2 rounded hover:bg-coral/90">Submit Question</button>
           </form>
@@ -323,53 +334,53 @@ export default function Home() {
             <>
               <div className="flex flex-col">
                 <span className="font-medium mb-1">I'm interested in*</span>
-                <div className="flex flex-wrap gap-2">
+                <div className="space-y-2">
                   {formOptions.map((opt) => (
-                    <button
-                      key={opt.value}
-                      type="button"
-                      onClick={() => setFormType(opt.value)}
-                      className={`px-4 py-2 rounded-full border ${
-                        formType === opt.value
-                          ? 'bg-lagoon text-white border-lagoon'
-                          : 'bg-white text-lagoon border-lagoon hover:bg-lagoon/10'
-                      }`}
-                      aria-pressed={formType === opt.value}
-                    >
-                      {opt.label}
-                    </button>
+                    <label key={opt.value} className="flex items-start space-x-2">
+                      <input
+                        type="checkbox"
+                        value={opt.value}
+                        checked={selected.includes(opt.value)}
+                        onChange={() => toggleSelection(opt.value)}
+                        className="mt-1"
+                      />
+                      <span>
+                        <span className="font-medium">{opt.label}</span> – {opt.desc}
+                      </span>
+                    </label>
                   ))}
                 </div>
               </div>
-              <div className="flex flex-col">
-                <label htmlFor="fname" className="font-medium mb-1">Name*</label>
-                <input id="fname" required type="text" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className="border p-2 rounded" />
-              </div>
-              <div className="flex flex-col">
-                <label htmlFor="femail" className="font-medium mb-1">Email*</label>
-                <input id="femail" required type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} className="border p-2 rounded" />
-              </div>
-              {(formType === 'updates' || formType === 'volunteer') && (
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <div className="flex flex-col">
+                  <label htmlFor="fname" className="font-medium mb-1">Name*</label>
+                  <input id="fname" name="name" autoComplete="name" required type="text" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className="border p-2 rounded" />
+                </div>
+                <div className="flex flex-col">
+                  <label htmlFor="femail" className="font-medium mb-1">Email*</label>
+                  <input id="femail" name="email" autoComplete="email" required type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} className="border p-2 rounded" />
+                </div>
                 <div className="flex flex-col">
                   <label htmlFor="fphone" className="font-medium mb-1">Mobile (optional)</label>
-                  <input id="fphone" type="text" value={form.phone} onChange={(e) => setForm({ ...form, phone: e.target.value })} className="border p-2 rounded" />
+                  <input id="fphone" name="phone" type="tel" inputMode="tel" autoComplete="tel" value={form.phone} onChange={(e) => setForm({ ...form, phone: e.target.value })} className="border p-2 rounded" />
                 </div>
-              )}
+              </div>
               <div className="flex flex-col">
                 <label htmlFor="fmessage" className="font-medium mb-1">Message (optional)</label>
-                <textarea id="fmessage" rows={4} value={form.message} onChange={(e) => setForm({ ...form, message: e.target.value })} className="border p-2 rounded" />
+                <textarea id="fmessage" name="message" rows={4} value={form.message} onChange={(e) => setForm({ ...form, message: e.target.value })} className="border p-2 rounded" />
               </div>
+              <p className="text-xs text-charcoal/70">We’ll use your information only for campaign purposes.</p>
             </>
           )}
           {mode === 'endorsement' && (
             <>
               <div className="flex flex-col">
                 <label htmlFor="ename" className="font-medium mb-1">Name*</label>
-                <input id="ename" required type="text" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className="border p-2 rounded" />
+                <input id="ename" name="name" autoComplete="name" required type="text" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className="border p-2 rounded" />
               </div>
               <div className="flex flex-col">
                 <label htmlFor="emessage" className="font-medium mb-1">Message (optional)</label>
-                <textarea id="emessage" rows={4} value={form.message} onChange={(e) => setForm({ ...form, message: e.target.value })} className="border p-2 rounded" />
+                <textarea id="emessage" name="message" rows={4} value={form.message} onChange={(e) => setForm({ ...form, message: e.target.value })} className="border p-2 rounded" />
               </div>
             </>
           )}

--- a/src/app/voting/page.js
+++ b/src/app/voting/page.js
@@ -9,28 +9,30 @@ export default function Voting() {
     <div className="space-y-8">
       <h1 className="text-3xl sm:text-4xl font-bold">Make Your Voice Count</h1>
       <p>
-        This election is more than filling two seats—it’s about setting the tone for homeowner-led governance in the near future. With the right leaders, these first homeowner‑elected seats can establish a culture of accountability, transparency, and unity.
+        This election is about more than filling two seats – it will set the tone for homeowner‑led governance for years to come. Your vote will establish a culture of accountability, transparency and unity.
       </p>
       <section>
         <h2 className="text-2xl font-bold mb-2">Key Dates</h2>
-        <ul className="list-disc list-inside space-y-1">
-          <li><strong>Meet the Candidates – Aug 14 @ 6 PM:</strong> Ask your questions, hear real answers, hold us accountable.</li>
-          <li><strong>Voting Opens – Aug 20:</strong> Vote online via Vote HOA Now — your chance to shape our future.</li>
-          <li><strong>Voting Closes – Sept 2:</strong> Don’t wait — make sure your voice is counted.</li>
-          <li><strong>Results Announced – Sept 3 Special Meeting:</strong> Attend to hear who will represent us.</li>
-        </ul>
+        <div className="flex flex-wrap gap-2 mb-2">
+          <div className="bg-lagoon-light text-lagoon px-3 py-1 rounded-full font-semibold uppercase text-xs sm:text-sm">Aug 14 – Meet the Candidates @ 6 PM</div>
+          <div className="bg-lagoon-light text-lagoon px-3 py-1 rounded-full font-semibold uppercase text-xs sm:text-sm">Aug 20 – Voting Opens</div>
+          <div className="bg-lagoon-light text-lagoon px-3 py-1 rounded-full font-semibold uppercase text-xs sm:text-sm">Sept 2 – Voting Closes</div>
+          <div className="bg-lagoon-light text-lagoon px-3 py-1 rounded-full font-semibold uppercase text-xs sm:text-sm">Sept 3 – Results Announced</div>
+          <div className="bg-lagoon-light text-lagoon px-3 py-1 rounded-full font-semibold uppercase text-xs sm:text-sm">1 Vote Per Address (Title Owner)</div>
+        </div>
       </section>
       <section>
         <h2 className="text-2xl font-bold mb-2">Voting Rules</h2>
-        <p>One vote per home address by a Title Owner. Look for your email from <strong>Vote HOA Now</strong> with your unique voting link. If you don’t receive it, contact HOA management for assistance.</p>
+        <p>One vote per home address by a Title Owner. Each Title Owner will receive a unique link via email from <strong>Vote HOA Now</strong>. If you don’t receive it, email <a href="mailto:hoa@windsong.org" className="underline">hoa@windsong.org</a> for assistance.</p>
       </section>
       <section>
         <h2 className="text-2xl font-bold mb-2">Why This Election Matters</h2>
-        <p>These two homeowner‑elected seats join three developer‑appointed members. While a developer majority remains today, <strong>your vote sets the tone</strong> for full homeowner governance in the near future. Accountability, transparency, and unity start with who you elect now.</p>
+        <p>These two homeowner‑elected seats join three developer‑appointed members. While a developer majority remains today, voting now lays the foundation for a fully homeowner‑led board. Your vote can accelerate our transition to full representation.</p>
       </section>
       <section>
         <h2 className="text-2xl font-bold mb-2">Role of a Board Member</h2>
-        <p>Board members are stewards of our shared home. They oversee budgets and reserves, set policy, guide maintenance and vendor performance, communicate decisions, and listen—truly listen—to homeowners. It’s collaborative work that balances today’s needs with tomorrow’s plans. When board members do it well, homeowners feel informed, heard, and confident about where we’re headed. That’s the Windsong we all want to live in.</p>
+        <p>Board members are stewards of our shared home. They oversee budgets and reserves, set policy, guide maintenance and vendor performance, communicate decisions and listen—truly listen—to homeowners. It’s collaborative work that balances today’s needs with tomorrow’s plans. When board members do it well, homeowners feel informed, heard and confident about where we’re headed.</p>
+        <p className="mt-2">My career in financial services and civic service prepares me to perform these duties with excellence. When evaluating candidates, ask: <em>Who will be a steward of your investment and a champion of our community?</em></p>
         <p className="mt-2"><Link href="/docs/board-member-101.pdf" target="_blank" rel="noopener noreferrer" className="text-lagoon underline">Download the official HOA Board Member overview (PDF)</Link></p>
       </section>
     </div>

--- a/src/components/MobileCTA.jsx
+++ b/src/components/MobileCTA.jsx
@@ -1,0 +1,21 @@
+"use client";
+import Link from 'next/link';
+
+export default function MobileCTA() {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 sm:hidden bg-white border-t shadow-md p-3 flex gap-2 z-50">
+      <Link
+        href={{ pathname: '/', query: { form: 'endorsement' }, hash: 'get-involved' }}
+        className="flex-1 text-center px-4 py-2 bg-coral text-white rounded-full font-semibold hover:bg-coral/90"
+      >
+        Endorse Doug
+      </Link>
+      <Link
+        href={{ pathname: '/', hash: 'get-involved' }}
+        className="flex-1 text-center px-4 py-2 bg-lagoon-light text-lagoon rounded-full font-semibold hover:bg-lagoon-light/90"
+      >
+        Get Involved
+      </Link>
+    </div>
+  );
+}

--- a/src/components/StickyNav.jsx
+++ b/src/components/StickyNav.jsx
@@ -33,17 +33,11 @@ export default function StickyNav() {
           <Link href="/voting" className="hover:underline">
             Voting Info
           </Link>
-          <Link href="/endorsements" className="hover:underline">
-            Endorsements
-          </Link>
-          <Link href="/qna" className="hover:underline">
-            Q&A
-          </Link>
           <Link
-            href={{ pathname: '/', hash: 'get-involved' }}
+            href={{ pathname: '/', hash: 'about' }}
             className="hover:underline"
           >
-            Get Involved
+            About Doug
           </Link>
         </div>
       </div>

--- a/src/lib/sendEmail.js
+++ b/src/lib/sendEmail.js
@@ -1,6 +1,17 @@
 import { Resend } from 'resend';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+let resend;
+
+function getResend() {
+  if (!resend) {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) {
+      throw new Error('RESEND_API_KEY must be configured');
+    }
+    resend = new Resend(apiKey);
+  }
+  return resend;
+}
 
 /**
  * Send a notification email using the Resend API.
@@ -15,7 +26,7 @@ export async function sendNotificationEmail(subject, text) {
   if (!from || !to) {
     throw new Error('SMTP_FROM and NOTIFY_EMAIL must be configured');
   }
-  await resend.emails.send({
+  await getResend().emails.send({
     from,
     to,
     subject,


### PR DESCRIPTION
## Summary
- Show key election dates as uppercase pills and add a mobile sticky CTA bar.
- Simplify navigation and refresh hero and pillar sections with stronger promises and icons.
- Improve forms and voting info; support multiple involvement options in the API.
- Lazily instantiate the Resend client to avoid build errors when the API key is absent.

## Testing
- `npm test` *(fails: Missing script "test")*
- `SUPABASE_URL=http://example.com SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE=service NEXT_TELEMETRY_DISABLED=1 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689947bbc22c8321b68ed76d4f6f8201