### PR TITLE
Await email sends

### DIFF
--- a/src/app/api/admin/endorsements/route.js
+++ b/src/app/api/admin/endorsements/route.js
@@ -39,7 +39,7 @@ export async function POST(req) {
       if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
       const site = process.env.SITE_URL || '';
       if (data?.email) {
-        sendEmail(
+        await sendEmail(
           data.email,
           'Your endorsement has been published',
           `Hi ${data.name || ''},\n\nYour endorsement is now live: ${site}/endorsements\n\nThank you for your support!\n\n--\nDoug Charles`

--- a/src/app/api/admin/qna/route.js
+++ b/src/app/api/admin/qna/route.js
@@ -39,7 +39,7 @@ export async function POST(req) {
       if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
       const site = process.env.SITE_URL || '';
       if (data?.email) {
-        sendEmail(
+        await sendEmail(
           data.email,
           'Your question has been answered',
           `Hi ${data.name || ''},\n\nYour question has been published: ${site}/qna\n\nThanks for reaching out!\n\n--\nDoug Charles`

--- a/src/app/api/endorsements/route.js
+++ b/src/app/api/endorsements/route.js
@@ -43,15 +43,17 @@ export async function POST(req) {
       if (error) {
         return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
       }
-      sendEmail(
-        email,
-        'Thanks for your endorsement',
-        `Hi ${name},\n\nThank you for endorsing Doug.\n${message ? `Your message: ${message}\n\n` : ''}We will notify you once it is published.\n\n--\nDoug Charles`
-      ).catch((err) => console.error('User email failed', err));
-      sendNotificationEmail(
-        'New endorsement submitted',
-        `Name: ${name}\nEmail: ${email}\nMessage: ${message || ''}`
-      ).catch((err) => console.error('Admin email failed', err));
+      await Promise.all([
+        sendEmail(
+          email,
+          'Thanks for your endorsement',
+          `Hi ${name},\n\nThank you for endorsing Doug.\n${message ? `Your message: ${message}\n\n` : ''}We will notify you once it is published.\n\n--\nDoug Charles`
+        ).catch((err) => console.error('User email failed', err)),
+        sendNotificationEmail(
+          'New endorsement submitted',
+          `Name: ${name}\nEmail: ${email}\nMessage: ${message || ''}`
+        ).catch((err) => console.error('Admin email failed', err))
+      ]);
       return NextResponse.json({ ok: true }, { status: 201 });
   } catch (err) {
     return NextResponse.json({ ok: false, error: err.message }, { status: 400 });

--- a/src/app/api/interest/route.js
+++ b/src/app/api/interest/route.js
@@ -32,15 +32,17 @@ export async function POST(req) {
       if (error) {
         return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
       }
-      sendEmail(
-        email,
-        'Thanks for getting involved',
-        `Hi ${name},\n\nThanks for your interest in ${type}.\n${message ? `Message: ${message}\n\n` : ''}We will be in touch and you can check back for updates.\n\n--\nDoug Charles`
-      ).catch((err) => console.error('User email failed', err));
-      sendNotificationEmail(
-        'New interest submission',
-        `Type: ${type}\nName: ${name}\nEmail: ${email}\nPhone: ${phone || ''}\nMessage: ${message || ''}`
-      ).catch((err) => console.error('Admin email failed', err));
+      await Promise.all([
+        sendEmail(
+          email,
+          'Thanks for getting involved',
+          `Hi ${name},\n\nThanks for your interest in ${type}.\n${message ? `Message: ${message}\n\n` : ''}We will be in touch and you can check back for updates.\n\n--\nDoug Charles`
+        ).catch((err) => console.error('User email failed', err)),
+        sendNotificationEmail(
+          'New interest submission',
+          `Type: ${type}\nName: ${name}\nEmail: ${email}\nPhone: ${phone || ''}\nMessage: ${message || ''}`
+        ).catch((err) => console.error('Admin email failed', err))
+      ]);
       return NextResponse.json({ ok: true }, { status: 201 });
   } catch (err) {
     return NextResponse.json({ ok: false, error: err.message }, { status: 400 });

--- a/src/app/api/questions/route.js
+++ b/src/app/api/questions/route.js
@@ -44,15 +44,17 @@ export async function POST(req) {
       if (error) {
         return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
       }
-      sendEmail(
-        email,
-        'Thanks for your question',
-        `Hi ${name},\n\nThanks for your question:\n${question}\n\nWe will follow up once it has been answered.\n\n--\nDoug Charles`
-      ).catch((err) => console.error('User email failed', err));
-      sendNotificationEmail(
-        'New question submitted',
-        `Name: ${name}\nEmail: ${email}\nQuestion: ${question}`
-      ).catch((err) => console.error('Admin email failed', err));
+      await Promise.all([
+        sendEmail(
+          email,
+          'Thanks for your question',
+          `Hi ${name},\n\nThanks for your question:\n${question}\n\nWe will follow up once it has been answered.\n\n--\nDoug Charles`
+        ).catch((err) => console.error('User email failed', err)),
+        sendNotificationEmail(
+          'New question submitted',
+          `Name: ${name}\nEmail: ${email}\nQuestion: ${question}`
+        ).catch((err) => console.error('Admin email failed', err))
+      ]);
       return NextResponse.json({ ok: true }, { status: 201 });
   } catch (err) {
     return NextResponse.json({ ok: false, error: err.message }, { status: 400 });


### PR DESCRIPTION
## Summary
- await both thank-you and notification emails in public form endpoints
- await notification emails in admin approval routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_689964f25af48321b8618e7d53504636