### PR TITLE
Improve header responsiveness and add icons

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <circle cx="16" cy="16" r="16" fill="#1B9AAA" />
+  <text x="16" y="21" text-anchor="middle" font-size="16" font-family="Arial" fill="white">D</text>
+</svg>

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -5,6 +5,9 @@ export const metadata = {
   title: 'Doug Charles for Windsong Ranch HOA',
   description: 'Campaign site for Windsong Ranch HOA board election',
   viewport: { width: 'device-width', initialScale: 1 },
+  icons: {
+    icon: '/favicon.svg',
+  },
 };
 
 const KEY_DATES = [

--- a/src/components/StickyNav.jsx
+++ b/src/components/StickyNav.jsx
@@ -1,10 +1,20 @@
 "use client";
 
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
+import {
+  FileText,
+  ThumbsUp,
+  HelpCircle,
+  User,
+  Menu,
+  X,
+} from 'lucide-react';
 
 export default function StickyNav() {
   const navRef = useRef(null);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     const navEl = navRef.current;
@@ -20,29 +30,51 @@ export default function StickyNav() {
     return () => window.removeEventListener('resize', updateOffset);
   }, []);
 
+  const toggle = () => setOpen((o) => !o);
+
   return (
     <nav
       ref={navRef}
       className="bg-white shadow-sm py-3 px-4 sticky [top:var(--banner-offset)] z-40"
     >
       <div className="max-w-6xl mx-auto flex justify-between items-center">
-        <Link href="/" className="text-xl font-bold text-lagoon">
-          Home
+        <Link href="/" className="flex items-center gap-2 text-xl font-bold text-lagoon">
+          <Image
+            src="/wsr-logo.png"
+            alt="Windsong Ranch logo"
+            width={32}
+            height={32}
+            className="h-8 w-8"
+          />
+          <span className="hidden sm:inline">Home</span>
         </Link>
-        <div className="flex gap-4 text-sm sm:text-base">
-          <Link href="/voting" className="hover:underline">
+        <button
+          className="sm:hidden p-2 text-lagoon"
+          onClick={toggle}
+          aria-label="Toggle navigation menu"
+        >
+          {open ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+        </button>
+        <div
+          className={`${open ? 'flex' : 'hidden'} flex-col sm:flex sm:flex-row sm:items-center gap-4 text-sm sm:text-base`}
+        >
+          <Link href="/voting" className="flex items-center gap-1 hover:underline">
+            <FileText className="h-4 w-4" />
             Voting Info
           </Link>
-          <Link href="/endorsements" className="hover:underline">
+          <Link href="/endorsements" className="flex items-center gap-1 hover:underline">
+            <ThumbsUp className="h-4 w-4" />
             Endorsements
           </Link>
-          <Link href="/qna" className="hover:underline">
-            Q&A
+          <Link href="/qna" className="flex items-center gap-1 hover:underline">
+            <HelpCircle className="h-4 w-4" />
+            Q&amp;A
           </Link>
           <Link
             href={{ pathname: '/', hash: 'about' }}
-            className="hover:underline"
+            className="flex items-center gap-1 hover:underline"
           >
+            <User className="h-4 w-4" />
             About Doug
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- make navigation responsive with mobile toggle and lucide icons
- replace binary favicon with SVG and reference it in metadata

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_68996850bf0c8321a1604571779b9dd4