### PR TITLE
Polish mobile layout and restore campaign visuals

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <circle cx="16" cy="16" r="16" fill="#1B9AAA" />
+  <text x="16" y="21" text-anchor="middle" font-size="16" font-family="Arial" fill="white">D</text>
+</svg>

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,10 +1,14 @@
 import './globals.css';
 import StickyNav from '../components/StickyNav';
+import MobileCTABar from '../components/MobileCTABar';
 
 export const metadata = {
   title: 'Doug Charles for Windsong Ranch HOA',
   description: 'Campaign site for Windsong Ranch HOA board election',
   viewport: { width: 'device-width', initialScale: 1 },
+  icons: {
+    icon: '/favicon.svg',
+  },
 };
 
 const KEY_DATES = [
@@ -41,7 +45,7 @@ export default function RootLayout({ children }) {
       <body>
         {/* Sticky key dates banner */}
         <header className="bg-lagoon text-white text-sm sm:text-base py-2 px-4 sticky top-0 z-50 shadow-md">
-          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-y-1">
+          <div className="flex flex-col sm:flex-row justify-center sm:justify-between items-center gap-y-1 text-center sm:text-left">
             <div className="flex flex-col sm:flex-row flex-wrap gap-x-4 gap-y-1">
               {KEY_DATES.map((item, idx) => (
                 <div key={idx} className="whitespace-nowrap">
@@ -53,26 +57,27 @@ export default function RootLayout({ children }) {
               </div>
             </div>
             {phase !== 'post' && (
-              <div className="ml-auto text-right">
+              <div className="sm:ml-auto sm:text-right">
                 {/* Highlight the countdown label and number so it stands out */}
                 <span className="font-semibold text-coral whitespace-nowrap uppercase">
                   {countdownText}
                 </span>
               </div>
             )}
-            </div>
-          </header>
+          </div>
+        </header>
         {/* Navigation */}
         <StickyNav />
-        <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pb-24 sm:pb-8">
           {children}
         </main>
-        <footer className="bg-white py-6 mt-16 border-t">
+        <footer className="bg-white py-6 mt-16 border-t pb-24 sm:pb-6">
           <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-sm text-center">
             Self‑funded by Doug Charles. | © {new Date().getFullYear()} Windsong Ranch HOA Election
           </div>
         </footer>
-      </body>
-    </html>
+        <MobileCTABar />
+        </body>
+      </html>
   );
 }

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -21,6 +21,9 @@ import {
   Home as HomeIcon,
   Compass,
   Link as LinkIcon,
+  FileText,
+  Megaphone,
+  Users,
 } from 'lucide-react';
 
 function HomeContent() {
@@ -187,21 +190,25 @@ function HomeContent() {
       {/* Promises */}
       <section className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
         <div className="card">
+          <FileText className="h-10 w-10 text-lagoon mb-2" />
           <h3 className="text-xl font-semibold mb-2">Ensure Transparency & Accountability</h3>
           <p>I will ensure every assessment, contract, and decision is clear and accessible to you. I’ll fight for open budgets, public explanations, and genuine two‑way dialogue.</p>
           <p className="quote mt-2">“Transparent governance isn’t optional—it’s a promise I make to you.”</p>
         </div>
         <div className="card">
+          <Megaphone className="h-10 w-10 text-lagoon mb-2" />
           <h3 className="text-xl font-semibold mb-2">Empower Homeowners & Amplify Your Voice</h3>
           <p>Homeowners—not developers—should drive our policies. We’ll staff committees with Windsong’s talented, passionate, and expert residents—and I’ll always be available to listen and advocate for your concerns.</p>
           <p className="quote mt-2">“Boards don’t own communities—homeowners do. Together we will build a board that serves you, not itself.”</p>
         </div>
         <div className="card">
+          <Users className="h-10 w-10 text-lagoon mb-2" />
           <h3 className="text-xl font-semibold mb-2">Unite Windsong</h3>
           <p>Townhomes, Villas, Peninsula, Crosswater, and every street—no neighborhood left behind. Our diversity is our strength, and we are stronger together.</p>
           <p className="quote mt-2">“Diverse in character, united in purpose—one Windsong, one voice.”</p>
         </div>
         <div className="card">
+          <Shield className="h-10 w-10 text-lagoon mb-2" />
           <h3 className="text-xl font-semibold mb-2">Protect Our Lifestyle & Practice Fiscal Stewardship</h3>
           <p>I’ll safeguard our reserve fund, minimize unnecessary assessment increases, and ensure our contracts deliver real value. We’ll protect and enhance our amenities—The Lagoon, trails, parks, and green spaces—so Windsong stays vibrant and thriving.</p>
           <p className="quote mt-2">“Our lifestyle is our legacy. I’ll ensure it’s preserved for all of us, today and tomorrow.”</p>
@@ -282,13 +289,18 @@ function HomeContent() {
       {/* Q&A published answers */}
       {questions.length > 0 && (
         <section>
-          <h2 className="text-2xl sm:text-3xl font-bold mb-4">Questions & Answers</h2>
-          <p className="mb-4">See recent questions answered, updated weekly.</p>
+          <h2 className="text-2xl sm:text-3xl font-bold mb-4">Recent Questions</h2>
+          <p className="mb-4">
+            See what neighbors are asking. Answers are on the{' '}
+            <Link href="/qna" className="underline">
+              Q&amp;A page
+            </Link>
+            .
+          </p>
           <div className="space-y-6">
             {questions.map((q) => (
               <div key={q.id} className="border-l-4 border-lagoon pl-4 py-2">
                 <p className="font-medium">Q: {q.question}</p>
-                <p className="mt-1">A: {q.answer}</p>
               </div>
             ))}
           </div>

--- a/src/components/MobileCTABar.jsx
+++ b/src/components/MobileCTABar.jsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+
+export default function MobileCTABar() {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-white border-t py-2 px-4 flex justify-around sm:hidden z-50">
+      <Link
+        href="/#get-involved"
+        className="bg-lagoon text-white px-4 py-2 rounded-full text-sm"
+      >
+        Get Involved
+      </Link>
+      <Link
+        href="/?form=endorsement#get-involved"
+        className="bg-coral text-white px-4 py-2 rounded-full text-sm"
+      >
+        Endorse Doug
+      </Link>
+    </div>
+  );
+}

--- a/src/components/StickyNav.jsx
+++ b/src/components/StickyNav.jsx
@@ -1,10 +1,20 @@
 "use client";
 
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import Link from 'next/link';
+import {
+  Home,
+  FileText,
+  ThumbsUp,
+  HelpCircle,
+  User,
+  Menu,
+  X,
+} from 'lucide-react';
 
 export default function StickyNav() {
   const navRef = useRef(null);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     const navEl = navRef.current;
@@ -20,29 +30,45 @@ export default function StickyNav() {
     return () => window.removeEventListener('resize', updateOffset);
   }, []);
 
+  const toggle = () => setOpen((o) => !o);
+
   return (
     <nav
       ref={navRef}
       className="bg-white shadow-sm py-3 px-4 sticky [top:var(--banner-offset)] z-40"
     >
       <div className="max-w-6xl mx-auto flex justify-between items-center">
-        <Link href="/" className="text-xl font-bold text-lagoon">
-          Home
+        <Link href="/" className="flex items-center gap-2 text-xl font-bold text-lagoon">
+          <Home className="h-6 w-6" />
+          <span className="hidden sm:inline">Home</span>
         </Link>
-        <div className="flex gap-4 text-sm sm:text-base">
-          <Link href="/voting" className="hover:underline">
+        <button
+          className="sm:hidden p-2 text-lagoon"
+          onClick={toggle}
+          aria-label="Toggle navigation menu"
+        >
+          {open ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+        </button>
+        <div
+          className={`${open ? 'flex' : 'hidden'} flex-col sm:flex sm:flex-row sm:items-center gap-4 text-sm sm:text-base`}
+        >
+          <Link href="/voting" className="flex items-center gap-1 hover:underline">
+            <FileText className="h-4 w-4" />
             Voting Info
           </Link>
-          <Link href="/endorsements" className="hover:underline">
+          <Link href="/endorsements" className="flex items-center gap-1 hover:underline">
+            <ThumbsUp className="h-4 w-4" />
             Endorsements
           </Link>
-          <Link href="/qna" className="hover:underline">
-            Q&A
+          <Link href="/qna" className="flex items-center gap-1 hover:underline">
+            <HelpCircle className="h-4 w-4" />
+            Q&amp;A
           </Link>
           <Link
             href={{ pathname: '/', hash: 'about' }}
-            className="hover:underline"
+            className="flex items-center gap-1 hover:underline"
           >
+            <User className="h-4 w-4" />
             About Doug
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- remove logo from nav and realign countdown for better mobile presentation
- add icons to promise cards and restore persistent mobile call-to-action bar
- show only questions on home page and link to full Q&A page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_68996850bf0c8321a1604571779b9dd4