### PR TITLE
fix(errors): resolve 3 error log issues

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,20 @@ const nextConfig = {
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
     formats: ['image/avif', 'image/webp'],
   },
+  async redirects() {
+    return [
+      {
+        source: '/poll',
+        destination: '/polls',
+        permanent: true,
+      },
+      {
+        source: '/poll/:path*',
+        destination: '/polls/:path*',
+        permanent: true,
+      },
+    ];
+  },
   async headers() {
     return [
       {

--- a/src/app/api/ideas/my-support/route.js
+++ b/src/app/api/ideas/my-support/route.js
@@ -41,6 +41,13 @@ export async function GET(request) {
       .eq('supporter_email', userEmail);
 
     if (error) {
+      await logError({
+        errorType: ErrorTypes.DATABASE_ERROR,
+        errorMessage: error.message,
+        endpoint: '/api/ideas/my-support',
+        method: 'GET',
+        request,
+      });
       return NextResponse.json(
         { ok: false, error: 'Failed to fetch supported ideas' },
         { status: 500 }

--- a/src/components/GetInvolvedDynamic.jsx
+++ b/src/components/GetInvolvedDynamic.jsx
@@ -64,6 +64,13 @@ function GetInvolvedDynamicContent() {
     setSubmitMsg('');
     setIsSubmitting(true);
 
+    // Validate name for non-endorsement forms
+    if (selectedAction !== 'endorsement' && !form.name.trim()) {
+      setSubmitMsg('Name is required.');
+      setIsSubmitting(false);
+      return;
+    }
+
     let validatedPhone = form.phone;
     if (form.phone && form.phone.trim()) {
       const { valid, formatted, error } = validatePhoneNumber(form.phone);

--- a/supabase/migrations/026_add_idea_supports_email_index.sql
+++ b/supabase/migrations/026_add_idea_supports_email_index.sql
@@ -1,0 +1,4 @@
+-- Fix 500 error on GET /api/ideas/my-support caused by full table scan
+-- The endpoint filters by supporter_email but no index existed for that column
+CREATE INDEX IF NOT EXISTS idx_idea_supports_supporter_email
+  ON idea_supports(supporter_email);


### PR DESCRIPTION
## Summary
- **`/poll` 404s (5x):** Added permanent redirect `/poll` → `/polls` in `next.config.js` for users/bots hitting the singular URL
- **Interest form "Name is required" (3x):** Added client-side name validation guard before API call in `GetInvolvedDynamic.jsx`
- **`/api/ideas/my-support` 500 (1x):** Added missing DB index on `idea_supports(supporter_email)` and added `logError` call for DB failures

## Test plan
- [ ] Visit `/poll` in browser → should redirect to `/polls`
- [ ] Visit `/poll/some-id` → should redirect to `/polls/some-id`
- [ ] Submit interest form with empty name → should show client-side error
- [ ] Verify migration 026 creates index (already run on Supabase)
- [ ] Hit `/api/ideas/my-support` as authenticated user → returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)